### PR TITLE
Use data path for instance when available

### DIFF
--- a/console/console_pane.cpp
+++ b/console/console_pane.cpp
@@ -20,7 +20,10 @@
 #include <QtGui/qmessagebox.h>
 
 ConsolePane::ConsolePane() : DzPane("Console") {
-  console = new Console(this, dzApp->getAppDataPath());
+  QString appDataInstancePath = dzApp->getAppDataPath();
+  QMetaObject::invokeMethod(dzApp, "getAppDataInstancePath", Qt::DirectConnection, Q_RETURN_ARG(QString, appDataInstancePath));
+
+  console = new Console(this, appDataInstancePath);
   consoleSettings = new ConsoleSettings(console->getLogFullPath());
   consoleLogBrowser = new ConsoleLogBrowser(console, consoleSettings);
   consoleSearchPane = new ConsoleSearchPane(consoleLogBrowser);


### PR DESCRIPTION
DAZ Studio 4.12.1.40 changed the way multiple instances of DS work. This change allows instances to reference the correct log file.